### PR TITLE
Lower resource limits to bring inline w/ dynatrace

### DIFF
--- a/base/passport-status-api/deployments.yaml
+++ b/base/passport-status-api/deployments.yaml
@@ -39,11 +39,11 @@ spec:
                 command: [ "sleep", "90" ]
           resources:
             requests:
-              cpu: 1000m
-              memory: 256Mi
-            limits:
-              cpu: 2000m
+              cpu: 125m
               memory: 1024Mi
+            limits:
+              cpu: 250m
+              memory: 2048Mi
           volumeMounts:
             - name: config
               mountPath: /workspace/BOOT-INF/classes/application-local.yaml

--- a/base/passport-status-frontend/deployments.yaml
+++ b/base/passport-status-frontend/deployments.yaml
@@ -35,11 +35,11 @@ spec:
             initialDelaySeconds: 10
           resources:
             requests:
+              cpu: 125m
+              memory: 128Mi
+            limits:
               cpu: 250m
               memory: 512Mi
-            limits:
-              cpu: 500m
-              memory: 1024Mi
           volumeMounts:
             - name: config
               mountPath: /app/.env

--- a/environments/dev/passport-status-api-deployments.yaml
+++ b/environments/dev/passport-status-api-deployments.yaml
@@ -20,11 +20,3 @@ spec:
           envFrom:
             - secretRef:
                 name: passport-status-api-dev
-          # increase resources because of embedded h2
-          resources:
-            requests:
-              cpu: 2000m
-              memory: 512Mi
-            limits:
-              cpu: 4000m
-              memory: 2048Mi

--- a/environments/local/passport-status-api-deployments.yaml
+++ b/environments/local/passport-status-api-deployments.yaml
@@ -11,11 +11,3 @@ spec:
     spec:
       containers:
         - name: passport-status-api
-          # increase resources because of embedded h2
-          resources:
-            requests:
-              cpu: 2000m
-              memory: 512Mi
-            limits:
-              cpu: 4000m
-              memory: 2048Mi

--- a/environments/nightly/passport-status-api-deployments.yaml
+++ b/environments/nightly/passport-status-api-deployments.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: passport-status-api
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: passport-status-api
@@ -27,8 +26,3 @@ spec:
             - secretRef:
                 name: passport-status-api-nightly
           imagePullPolicy: Always
-          # increase resources to accommodate database seeding
-          resources:
-            limits:
-              cpu: 4000m
-              memory: 4096Mi

--- a/environments/nightly/passport-status-frontend-deployments.yaml
+++ b/environments/nightly/passport-status-frontend-deployments.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   name: passport-status-frontend
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: passport-status-frontend

--- a/environments/prod/passport-status-api-deployments.yaml
+++ b/environments/prod/passport-status-api-deployments.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: passport-status-api
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: passport-status-api
@@ -26,8 +26,3 @@ spec:
           envFrom:
             - secretRef:
                 name: passport-status-api-prod
-          # increase resources to accommodate database seeding
-          resources:
-            limits:
-              cpu: 4000m
-              memory: 4096Mi

--- a/environments/prod/passport-status-frontend-deployments.yaml
+++ b/environments/prod/passport-status-frontend-deployments.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: passport-status-frontend
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: passport-status-frontend

--- a/environments/staging/passport-status-api-deployments.yaml
+++ b/environments/staging/passport-status-api-deployments.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: passport-status-api
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: passport-status-api
@@ -26,8 +26,3 @@ spec:
           envFrom:
             - secretRef:
                 name: passport-status-api-staging
-          # increase resources to accommodate database seeding
-          resources:
-            limits:
-              cpu: 4000m
-              memory: 4096Mi

--- a/environments/staging/passport-status-frontend-deployments.yaml
+++ b/environments/staging/passport-status-frontend-deployments.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: passport-status-frontend
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: passport-status-frontend


### PR DESCRIPTION
Dynatrace is indicating that we are reserving far more resources for the application than we need, even when under load. This PR reduces the CPU and memory limits to match more closely what Dynatrace is reporting the applications need.