### PR TITLE
Increase CPU limits for API

### DIFF
--- a/base/passport-status-api/deployments.yaml
+++ b/base/passport-status-api/deployments.yaml
@@ -39,10 +39,10 @@ spec:
                 command: [ "sleep", "90" ]
           resources:
             requests:
-              cpu: 125m
+              cpu: 250m
               memory: 1024Mi
             limits:
-              cpu: 250m
+              cpu: 500m
               memory: 2048Mi
           volumeMounts:
             - name: config


### PR DESCRIPTION
As per title. API is too slow to start with existing limits.