### PR TITLE
Add service for maintenance application

### DIFF
--- a/base/passport-status-maintenance/kustomization.yaml
+++ b/base/passport-status-maintenance/kustomization.yaml
@@ -5,3 +5,4 @@ commonLabels:
   app.kubernetes.io/managed-by: kustomize
 resources:
   - deployments.yaml
+  - services.yaml

--- a/base/passport-status-maintenance/services.yaml
+++ b/base/passport-status-maintenance/services.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: passport-status-maintenance
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: passport-status-maintenance
+    app.kubernetes.io/component: maintenance


### PR DESCRIPTION
This will allow us to quickly update an ingress service-name to load the maintenance app during downtime.