### PR TITLE
Deploy Crunchy PGO in prep for new DBs

### DIFF
--- a/environments/shared-prod/README.md
+++ b/environments/shared-prod/README.md
@@ -1,0 +1,4 @@
+# GitOps Shared Environment
+
+This directory contains the manifests and configurations that are common to each prod environments. The
+configurations and applications that are defined here can be deployed to any Kubernetes namespace.

--- a/environments/shared-prod/kustomization.yaml
+++ b/environments/shared-prod/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  # commonLabels must have at least one unique label
+  # per environment to ensure selectors are applied correctly
+  app.kubernetes.io/instance: shared-prod
+bases:
+  - ../../base/postgres-operator/
+namespace: passport-status


### PR DESCRIPTION
**Note:** this changeset has **already been applied to the cluster** from my localhost using the following command:

``` bash
➜  passport-status-gitops git:(development) ✗ kubectl --kubeconfig ~/.kube/dts-prod-sced-rhp-spoke-aks.yaml apply --kustomize environments/shared-prod/                 
serviceaccount/postgres-operator created
serviceaccount/postgres-operator-upgrade created
role.rbac.authorization.k8s.io/postgres-operator created
role.rbac.authorization.k8s.io/postgres-operator-upgrade created
rolebinding.rbac.authorization.k8s.io/postgres-operator created
rolebinding.rbac.authorization.k8s.io/postgres-operator-upgrade created
deployment.apps/postgres-operator created
deployment.apps/postgres-operator-upgrade created
```

![image](https://github.com/DTS-STN/passport-status-gitops/assets/48123208/458395fc-3033-49fd-9eff-ed209d38d792)
