### PR TITLE
Deploy PostgresCluster to prod

### DIFF
--- a/environments/prod/kustomization.yaml
+++ b/environments/prod/kustomization.yaml
@@ -6,6 +6,7 @@ commonLabels:
   app.kubernetes.io/instance: prod
 bases:
   - ../../base/passport-status-api/
+  - ../../base/passport-status-db/
   - ../../base/passport-status-frontend/
   - ../../base/passport-status-maintenance/
 images:
@@ -21,19 +22,39 @@ images:
 namespace: passport-status
 nameSuffix: -prod
 patchesStrategicMerge:
-  - passport-status-api-configmaps.yaml
-  - passport-status-api-deployments.yaml
-  - passport-status-frontend-configmaps.yaml
-  - passport-status-frontend-deployments.yaml
-  - passport-status-maintenance-deployments.yaml
+  - ./passport-status-api-configmaps.yaml
+  - ./passport-status-api-deployments.yaml
+  - ./passport-status-frontend-configmaps.yaml
+  - ./passport-status-frontend-deployments.yaml
+  - ./passport-status-maintenance-deployments.yaml
 resources:
-  - artemis-deployments.yaml
-  - artemis-security-deployments.yaml
-  - passport-status-api-hpas.yaml
-  - passport-status-api-ingresses.yaml
-  - passport-status-frontend-hpas.yaml
-  - passport-status-frontend-ingresses.yaml
+  - ./artemis-deployments.yaml
+  - ./artemis-security-deployments.yaml
+  - ./passport-status-api-hpas.yaml
+  - ./passport-status-api-ingresses.yaml
+  - ./passport-status-frontend-hpas.yaml
+  - ./passport-status-frontend-ingresses.yaml
 secretGenerator:
 - name: passport-status-api
   envs:
-  - .env.api.secret
+  - ./.env.api.secret
+patches:
+  - target:
+      kind: PostgresCluster
+      name: passport-status-db
+    patch: |-
+      - op: replace
+        path: /spec/instances/0/dataVolumeClaimSpec/resources/requests/storage
+        value: 1024Gi
+      - op: replace
+        path: /spec/backups/pgbackrest/repos/0/volume/volumeClaimSpec/resources/requests/storage
+        value: 1024Gi
+      - op: replace
+        path: /spec/instances/0/affinity/podAntiAffinity/preferredDuringSchedulingIgnoredDuringExecution/0/podAffinityTerm/labelSelector/matchLabels/postgres-operator.crunchydata.com~1cluster
+        value: passport-status-db-prod
+      - op: replace
+        path: /spec/proxy/pgBouncer/affinity/podAntiAffinity/preferredDuringSchedulingIgnoredDuringExecution/0/podAffinityTerm/labelSelector/matchLabels/postgres-operator.crunchydata.com~1cluster
+        value: passport-status-db-prod
+      - op: replace
+        path: /spec/databaseInitSQL/name
+        value: passport-status-db-prod


### PR DESCRIPTION
**Note:** this changeset has already been applied to the cluster from my localhost using the following command:

``` bash
➜  passport-status-gitops git:(development) kubectl --kubeconfig ~/.kube/dts-prod-sced-rhp-spoke-aks.yaml apply --kustomize environments/prod/                 
configmap/passport-status-api-cm-prod unchanged
configmap/passport-status-db-prod created
configmap/passport-status-frontend-cm-prod unchanged
secret/passport-status-api-prod-576h82cbf4 configured
service/passport-status-api-prod unchanged
service/passport-status-frontend-prod unchanged
service/passport-status-maintenance-prod unchanged
deployment.apps/passport-status-api-prod configured
deployment.apps/passport-status-frontend-prod configured
deployment.apps/passport-status-maintenance-prod configured
horizontalpodautoscaler.autoscaling/passport-status-api-prod unchanged
horizontalpodautoscaler.autoscaling/passport-status-frontend-prod unchanged
activemqartemis.broker.amq.io/passport-status-amq-prod unchanged
activemqartemissecurity.broker.amq.io/passport-status-amq-security-prod unchanged
ingress.networking.k8s.io/passport-status-amq-wconsj-prod unchanged
ingress.networking.k8s.io/passport-status-api-prod unchanged
ingress.networking.k8s.io/passport-status-frontend-prod unchanged
ingress.networking.k8s.io/public-passport-status-frontend-prod unchanged
postgrescluster.postgres-operator.crunchydata.com/passport-status-db-prod created
```

![image](https://github.com/DTS-STN/passport-status-gitops/assets/48123208/4443f18a-c69f-43af-99f0-11d295d21303)
