### PR TITLE
Fix broken API configuration

### DIFF
--- a/environments/staging/passport-status-api-deployments.yaml
+++ b/environments/staging/passport-status-api-deployments.yaml
@@ -21,8 +21,8 @@ spec:
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: staging-postgresql-ha-postgresql
-                  key: postgresql-password
+                  name: passport-status-db-staging-pguser-passport-status
+                  key: password
           # increase resources to accommodate database seeding
           resources:
             limits:


### PR DESCRIPTION
A configuration was missed when migrating to Crunchy. Amazingly, because the old secret still existed in the cluster, everything worked fine until today.