### PR TITLE
Adjust postgres resources to be higher than defaults

### DIFF
--- a/base/passport-status-db-cn/postgres-clusters.yaml
+++ b/base/passport-status-db-cn/postgres-clusters.yaml
@@ -13,6 +13,14 @@ spec:
         name: passport-status-db-cn
   postgresql:
     parameters:
+      shared_buffers: "256MB"
       wal_keep_size: 1GB
+  resources:
+    requests:
+      memory: "1024Mi"
+      cpu: 1
+    limits:
+      memory: "1024Mi"
+      cpu: 1
   storage:
     size: 64Gi


### PR DESCRIPTION
Based on resource management here:
https://cloudnative-pg.io/documentation/1.20/resource_management/

We might be able to go lower, but for now want to make sure we aren't CPU starved when doing large updates.

Also if this is too big in staging we can update the values there later.