### PR TITLE
feat(ingress): add TLS configuration for production and staging environments

### DIFF
--- a/environments/prod/artemis-deployments.yaml
+++ b/environments/prod/artemis-deployments.yaml
@@ -13,7 +13,7 @@ spec:
     # https://github.com/artemiscloud/activemq-artemis-operator/issues/187
     podSecurityContext:
       fsGroup: 0
-      fsGroupChangePolicy: "OnRootMismatch"
+      fsGroupChangePolicy: 'OnRootMismatch'
   console:
     expose: true
 
@@ -27,6 +27,13 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret 'proddpinternaldtsstncom' is provisioned by the cluster platform.
+    - secretName: proddpinternaldtsstncom
+      hosts:
+        - passport-status-amq-wconsj-0.prod-dp-internal.dts-stn.com
+        - passport-status-amq-wconsj-1.prod-dp-internal.dts-stn.com
+        - passport-status-amq-wconsj-2.prod-dp-internal.dts-stn.com
   rules:
     - host: passport-status-amq-wconsj-0.prod-dp-internal.dts-stn.com
       http:

--- a/environments/prod/passport-status-api-ingresses.yaml
+++ b/environments/prod/passport-status-api-ingresses.yaml
@@ -6,6 +6,11 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret 'proddpinternaldtsstncom' is provisioned by the cluster platform.
+    - secretName: proddpinternaldtsstncom
+      hosts:
+        - passport-status-api.prod-dp-internal.dts-stn.com
   rules:
     - host: passport-status-api.prod-dp-internal.dts-stn.com
       http:

--- a/environments/prod/passport-status-frontend-ingresses.yaml
+++ b/environments/prod/passport-status-frontend-ingresses.yaml
@@ -6,6 +6,11 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret 'proddpinternaldtsstncom' is provisioned by the cluster platform.
+    - secretName: proddpinternaldtsstncom
+      hosts:
+        - passport-status.prod-dp-internal.dts-stn.com
   rules:
     - host: passport-status.prod-dp-internal.dts-stn.com
       http:
@@ -19,7 +24,6 @@ spec:
                   name: http
 
 ---
-
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,6 +32,11 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret 'wildcardservicecanadaca' is provisioned by the cluster platform.
+    - secretName: wildcardservicecanadaca
+      hosts:
+        - etatpasseport-passportstatus.service.canada.ca
   rules:
     - host: etatpasseport-passportstatus.service.canada.ca
       http:

--- a/environments/staging/artemis-deployments.yaml
+++ b/environments/staging/artemis-deployments.yaml
@@ -15,7 +15,7 @@ spec:
     # https://github.com/artemiscloud/activemq-artemis-operator/issues/187
     podSecurityContext:
       fsGroup: 0
-      fsGroupChangePolicy: "OnRootMismatch"
+      fsGroupChangePolicy: 'OnRootMismatch'
   console:
     expose: true
 
@@ -29,6 +29,11 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret 'devdpinternaldtsstncom' is provisioned by the cluster platform.
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - passport-status-amq-wconsj-0-staging.dev-dp-internal.dts-stn.com
   rules:
     - host: passport-status-amq-wconsj-0-staging.dev-dp-internal.dts-stn.com
       http:

--- a/environments/staging/passport-status-api-ingresses.yaml
+++ b/environments/staging/passport-status-api-ingresses.yaml
@@ -6,6 +6,11 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret 'devdpinternaldtsstncom' is provisioned by the cluster platform.
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - passport-status-api-staging.dev-dp-internal.dts-stn.com
   rules:
     - host: passport-status-api-staging.dev-dp-internal.dts-stn.com
       http:
@@ -19,7 +24,6 @@ spec:
                   name: http
 
 ---
-
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,6 +32,11 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret 'devdpdtsstncom' is provisioned by the cluster platform.
+    - secretName: devdpdtsstncom
+      hosts:
+        - passport-status-api-staging.dev-dp.dts-stn.com
   rules:
     - host: passport-status-api-staging.dev-dp.dts-stn.com
       http:

--- a/environments/staging/passport-status-frontend-ingresses.yaml
+++ b/environments/staging/passport-status-frontend-ingresses.yaml
@@ -6,6 +6,11 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret 'devdpinternaldtsstncom' is provisioned by the cluster platform.
+    - secretName: devdpinternaldtsstncom
+      hosts:
+        - passport-status-staging.dev-dp-internal.dts-stn.com
   rules:
     - host: passport-status-staging.dev-dp-internal.dts-stn.com
       http:
@@ -19,7 +24,6 @@ spec:
                   name: http
 
 ---
-
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -31,6 +35,11 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
 spec:
   ingressClassName: nginx
+  tls:
+    # TLS secret 'devdpdtsstncom' is provisioned by the cluster platform.
+    - secretName: devdpdtsstncom
+      hosts:
+        - passport-status-staging.dev-dp.dts-stn.com
   rules:
     - host: passport-status-staging.dev-dp.dts-stn.com
       http:


### PR DESCRIPTION
This pull request updates the ingress configurations for both production and staging environments to explicitly define TLS settings for all relevant services. The main goal is to ensure secure HTTPS connections by specifying the required TLS secrets and associated hosts. Additionally, there are minor YAML style adjustments for consistency.